### PR TITLE
Add record elimination, tests and docs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "purescript-maybe": "^3.0.0",
     "purescript-typelevel-prelude": "^2.3.1",
     "purescript-lists": "^4.9.0",
-    "purescript-record": "^0.1.0"
+    "purescript-record": "0.2.0"
   },
   "devDependencies": {
     "purescript-console": "^3.0.0",

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,9 @@
     "purescript-symbols": "^3.0.0",
     "purescript-unsafe-coerce": "^3.0.0",
     "purescript-partial": "^1.2.0",
-    "purescript-maybe": "^3.0.0"
+    "purescript-maybe": "^3.0.0",
+    "purescript-typelevel-prelude": "^2.3.1",
+    "purescript-maps": "^3.4.0"
   },
   "devDependencies": {
     "purescript-console": "^3.0.0",

--- a/bower.json
+++ b/bower.json
@@ -30,8 +30,8 @@
     "purescript-partial": "^1.2.0",
     "purescript-maybe": "^3.0.0",
     "purescript-typelevel-prelude": "^2.3.1",
-    "purescript-maps": "^3.4.0",
-    "purescript-lists": "^4.9.0"
+    "purescript-lists": "^4.9.0",
+    "purescript-record": "^0.1.0"
   },
   "devDependencies": {
     "purescript-console": "^3.0.0",

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "purescript-unsafe-coerce": "^3.0.0",
     "purescript-partial": "^1.2.0",
     "purescript-maybe": "^3.0.0",
-    "purescript-typelevel-prelude": "^2.3.1",
+    "purescript-typelevel-prelude": "^2.4.0",
     "purescript-lists": "^4.9.0",
     "purescript-record": "0.2.0"
   },

--- a/src/Data/Functor/Variant.purs
+++ b/src/Data/Functor/Variant.purs
@@ -1,23 +1,27 @@
 module Data.Functor.Variant
   ( VariantF
-  , FProxy(..)
   , inj
   , prj
   , on
   , case_
-  , contract
   , default
+  , match
+  , expand
+  , contract
   , module Exports
   ) where
 
 import Prelude
+
 import Control.Alternative (class Alternative, empty)
-import Data.Symbol (SProxy, class IsSymbol, reflectSymbol)
+import Data.Maybe (fromJust)
+import Data.StrMap as SM
 import Data.Symbol (SProxy(..)) as Exports
+import Data.Symbol (SProxy, class IsSymbol, reflectSymbol)
 import Data.Tuple (Tuple(..), fst)
-import Data.Variant.Internal (class Contractable, contractWith, VariantCase, RProxy(..))
-import Data.Variant.Internal (class Contractable) as Exports
-import Partial.Unsafe (unsafeCrashWith)
+import Data.Variant.Internal (class Contractable, contractWith, VariantCase, class VRFMatching, RProxy(..), FProxy)
+import Data.Variant.Internal (class Contractable, FProxy(..)) as Exports
+import Partial.Unsafe (unsafeCrashWith, unsafePartial)
 import Unsafe.Coerce (unsafeCoerce)
 
 data FBox (f ∷ Type → Type) a = FBox (∀ x y. (x → y) → f x → f y) (f a)
@@ -37,8 +41,6 @@ instance functorVariantF ∷ Functor (VariantF r) where
 
     coerceV ∷ ∀ f a. Tuple String (FBox f a) → VariantF r a
     coerceV = unsafeCoerce
-
-data FProxy (a ∷ Type → Type) = FProxy
 
 -- | Inject into the variant at a given label.
 -- | ```purescript
@@ -118,6 +120,36 @@ case_ r = unsafeCrashWith case unsafeCoerce r of
 -- | ```
 default ∷ ∀ a b r. a → VariantF r b → a
 default a _ = a
+
+-- | Match a `variant` with a `record` containing methods to handle each case
+-- | to produce a `result`.
+-- |
+-- | This means that if `variant` contains a row of type `FProxy f`, a row with
+-- | the same label must have type `f a -> result` in `record`, where `result`
+-- | is the same type for every row of `record`.
+-- |
+-- | Polymorphic methods in `record` may create problems with the type system
+-- | if the polymorphism is not fully generalized to the whole record type
+-- | or if not all polymorphic variables are specified in usage. When in doubt,
+-- | label methods with specific types, such as `show :: Int -> String`, or
+-- | give the whole record an appropriate type.
+match
+  ∷ ∀ variant record typearg result
+  . VRFMatching variant record typearg result
+  ⇒ VariantF variant typearg
+  → Record record
+  → result
+match v r =
+  case coerceV v of
+    Tuple tag (FBox _ a) →
+      a # unsafePartial fromJust
+        (SM.lookup tag (coerceR r))
+  where
+  coerceV ∷ ∀ f. VariantF variant typearg → Tuple String (FBox f typearg)
+  coerceV = unsafeCoerce
+
+  coerceR ∷ ∀ a. Record record → SM.StrMap a
+  coerceR = unsafeCoerce
 
 -- | Every `VariantF lt a` can be cast to some `VariantF gt a` as long as `lt` is a
 -- | subset of `gt`.

--- a/src/Data/Functor/Variant.purs
+++ b/src/Data/Functor/Variant.purs
@@ -17,8 +17,8 @@ import Control.Alternative (class Alternative, empty)
 import Data.Symbol (SProxy(..)) as Exports
 import Data.Symbol (SProxy, class IsSymbol, reflectSymbol)
 import Data.Tuple (Tuple(..), fst)
+import Data.Variant.Internal (class Contractable, contractWith, VariantCase, class VariantFRecordMatching, RProxy(..), FProxy, unsafeGet)
 import Data.Variant.Internal (class Contractable, FProxy(..)) as Exports
-import Data.Variant.Internal (class Contractable, contractWith, VariantCase, class VRFMatching, RProxy(..), FProxy, unsafeGet)
 import Partial.Unsafe (unsafeCrashWith)
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -133,7 +133,7 @@ default a _ = a
 -- | give the whole record an appropriate type.
 match
   ∷ ∀ variant record typearg result
-  . VRFMatching variant record typearg result
+  . VariantFRecordMatching variant record typearg result
   ⇒ Record record
   → VariantF variant typearg
   → result

--- a/src/Data/Functor/Variant.purs
+++ b/src/Data/Functor/Variant.purs
@@ -136,10 +136,10 @@ default a _ = a
 match
   ∷ ∀ variant record typearg result
   . VRFMatching variant record typearg result
-  ⇒ VariantF variant typearg
-  → Record record
+  ⇒ Record record
+  → VariantF variant typearg
   → result
-match v r =
+match r v =
   case coerceV v of
     Tuple tag (FBox _ a) →
       a # unsafePartial fromJust

--- a/src/Data/Functor/Variant.purs
+++ b/src/Data/Functor/Variant.purs
@@ -14,14 +14,12 @@ module Data.Functor.Variant
 import Prelude
 
 import Control.Alternative (class Alternative, empty)
-import Data.Maybe (fromJust)
-import Data.StrMap as SM
 import Data.Symbol (SProxy(..)) as Exports
 import Data.Symbol (SProxy, class IsSymbol, reflectSymbol)
 import Data.Tuple (Tuple(..), fst)
-import Data.Variant.Internal (class Contractable, contractWith, VariantCase, class VRFMatching, RProxy(..), FProxy)
 import Data.Variant.Internal (class Contractable, FProxy(..)) as Exports
-import Partial.Unsafe (unsafeCrashWith, unsafePartial)
+import Data.Variant.Internal (class Contractable, contractWith, VariantCase, class VRFMatching, RProxy(..), FProxy, unsafeGet)
+import Partial.Unsafe (unsafeCrashWith)
 import Unsafe.Coerce (unsafeCoerce)
 
 data FBox (f ∷ Type → Type) a = FBox (∀ x y. (x → y) → f x → f y) (f a)
@@ -142,14 +140,10 @@ match
 match r v =
   case coerceV v of
     Tuple tag (FBox _ a) →
-      a # unsafePartial fromJust
-        (SM.lookup tag (coerceR r))
+      a # unsafeGet tag r
   where
   coerceV ∷ ∀ f. VariantF variant typearg → Tuple String (FBox f typearg)
   coerceV = unsafeCoerce
-
-  coerceR ∷ ∀ a. Record record → SM.StrMap a
-  coerceR = unsafeCoerce
 
 -- | Every `VariantF lt a` can be cast to some `VariantF gt a` as long as `lt` is a
 -- | subset of `gt`.

--- a/src/Data/Variant.purs
+++ b/src/Data/Variant.purs
@@ -14,18 +14,17 @@ module Data.Variant
   ) where
 
 import Prelude
+
 import Control.Alternative (empty, class Alternative)
 import Data.List as L
-import Data.Maybe (fromJust)
+import Data.Symbol (SProxy(..)) as Exports
 import Data.Symbol (SProxy, class IsSymbol, reflectSymbol)
 import Data.Tuple (Tuple(..), fst)
-import Data.Variant.Internal (RLProxy(..), class VariantTags, variantTags, VariantCase, lookupEq, lookupOrd, class Contractable, RProxy(..), contractWith, class VRMatching)
+import Data.Variant.Internal (RLProxy(..), class VariantTags, variantTags, VariantCase, lookupEq, lookupOrd, class Contractable, RProxy(..), contractWith, class VRMatching, unsafeGet)
 import Data.Variant.Internal (class Contractable) as Exports
-import Data.Symbol (SProxy(..)) as Exports
-import Partial.Unsafe (unsafeCrashWith, unsafePartial)
+import Partial.Unsafe (unsafeCrashWith)
 import Type.Row as R
 import Unsafe.Coerce (unsafeCoerce)
-import Data.StrMap as SM
 
 foreign import data Variant ∷ # Type → Type
 
@@ -128,14 +127,10 @@ match
 match r v =
   case coerceV v of
     Tuple tag a →
-      a # unsafePartial fromJust
-        (SM.lookup tag (coerceR r))
+      a # unsafeGet tag r
   where
   coerceV ∷ ∀ a. Variant variant → Tuple String a
   coerceV = unsafeCoerce
-
-  coerceR ∷ ∀ a. Record record → SM.StrMap a
-  coerceR = unsafeCoerce
 
 -- | Every `Variant lt` can be cast to some `Variant gt` as long as `lt` is a
 -- | subset of `gt`.

--- a/src/Data/Variant.purs
+++ b/src/Data/Variant.purs
@@ -20,7 +20,7 @@ import Data.List as L
 import Data.Symbol (SProxy(..)) as Exports
 import Data.Symbol (SProxy, class IsSymbol, reflectSymbol)
 import Data.Tuple (Tuple(..), fst)
-import Data.Variant.Internal (RLProxy(..), class VariantTags, variantTags, VariantCase, lookupEq, lookupOrd, class Contractable, RProxy(..), contractWith, class VRMatching, unsafeGet)
+import Data.Variant.Internal (RLProxy(..), class VariantTags, variantTags, VariantCase, lookupEq, lookupOrd, class Contractable, RProxy(..), contractWith, class VariantRecordMatching, unsafeGet)
 import Data.Variant.Internal (class Contractable) as Exports
 import Partial.Unsafe (unsafeCrashWith)
 import Type.Row as R
@@ -120,7 +120,7 @@ default a _ = a
 -- | give the whole record an appropriate type.
 match
   ∷ ∀ variant record result
-  . VRMatching variant record result
+  . VariantRecordMatching variant record result
   ⇒ Record record
   → Variant variant
   → result

--- a/src/Data/Variant.purs
+++ b/src/Data/Variant.purs
@@ -111,8 +111,8 @@ default a _ = a
 -- | to produce a `result`.
 -- |
 -- | This means that if `variant` contains a row of type `a`, a row with the
--- | same label must have type `a -> b` in `record`, where `b` is the same
--- | `result` type for every row of `record`.
+-- | same label must have type `a -> result` in `record`, where `result` is the
+-- | same type for every row of `record`.
 -- |
 -- | Polymorphic methods in `record` may create problems with the type system
 -- | if the polymorphism is not fully generalized to the whole record type

--- a/src/Data/Variant.purs
+++ b/src/Data/Variant.purs
@@ -122,10 +122,10 @@ default a _ = a
 match
   ∷ ∀ variant record result
   . VRMatching variant record result
-  ⇒ Variant variant
-  → Record record
+  ⇒ Record record
+  → Variant variant
   → result
-match v r =
+match r v =
   case coerceV v of
     Tuple tag a →
       a # unsafePartial fromJust

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -1,7 +1,5 @@
 module Data.Variant.Internal
-  ( RLProxy(..)
-  , RProxy(..)
-  , FProxy(..)
+  ( FProxy(..)
   , VariantCase
   , class VariantTags, variantTags
   , class Contractable, contractWith
@@ -23,11 +21,10 @@ import Data.Tuple (Tuple(..))
 import Data.Record.Unsafe (unsafeGet) as Exports
 import Partial.Unsafe (unsafeCrashWith)
 import Type.Row as R
+import Type.Row (RProxy, RLProxy(..))
+import Type.Row (RProxy(..), RLProxy(..)) as Exports
 
-data RProxy (r ∷ # Type) = RProxy
-
-data RLProxy (rl ∷ R.RowList) = RLProxy
-
+-- | Proxy for a `Functor`.
 data FProxy (a ∷ Type → Type) = FProxy
 
 -- | Type class that matches a row for a `record` that will eliminate a row for

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -12,14 +12,17 @@ module Data.Variant.Internal
   , lookupTag
   , lookupEq
   , lookupOrd
+  , unsafeGet
   ) where
 
 import Prelude
 import Control.Alternative (class Alternative, empty)
 import Data.List as L
-import Data.Symbol (SProxy(..), class IsSymbol, reflectSymbol)
+import Data.Symbol (SProxy(..), class IsSymbol, reflectSymbol, reifySymbol)
 import Data.Tuple (Tuple(..))
+import Data.Record as Rec
 import Partial.Unsafe (unsafeCrashWith)
+import Unsafe.Coerce (unsafeCoerce)
 import Type.Row as R
 
 data RProxy (r ∷ # Type) = RProxy
@@ -163,3 +166,15 @@ instance contractWithInstance
   contractWith _ _ tag a
     | lookupTag tag (variantTags (RLProxy ∷ RLProxy ltl)) = pure a
     | otherwise = empty
+
+unsafeGet ∷ ∀ a r. String -> Record r -> a
+unsafeGet tag r = unsafeReifyLabelIn tag r (flip Rec.get r)
+
+unsafeReifyLabelIn :: ∀ a r. String -> Record r -> (∀ l r'. RowCons l a r' r => IsSymbol l => SProxy l -> a) -> a
+unsafeReifyLabelIn tag r f = reifySymbol tag noRowCons
+  where
+    coerce :: (∀ l r'. RowCons l a r' r => IsSymbol l => SProxy l -> a)
+           -> {} -> (∀ l. IsSymbol l => SProxy l -> a)
+    coerce = unsafeCoerce
+    noRowCons :: ∀ l. IsSymbol l => SProxy l -> a
+    noRowCons = coerce f {}

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -35,8 +35,7 @@ class VRMatching
     (variant ∷ # Type)
     (record ∷ # Type)
     result
-  | variant result → record
-  , record → variant result
+  | → variant record result
 instance variantRecordMatching
   ∷ ( R.RowToList variant vlist
     , R.RowToList record rlist
@@ -52,7 +51,7 @@ class RLMatch
     (vlist ∷ R.RowList)
     (rlist ∷ R.RowList)
     result
-  | vlist result → rlist
+  | vlist → rlist result
   , rlist → vlist result
 instance variantMatchNil
   ∷ RLMatch R.Nil R.Nil r
@@ -65,8 +64,7 @@ class VRFMatching
     (record ∷ # Type)
     typearg
     result
-  | variant typearg result → record
-  , record → variant typearg result
+  | → variant record typearg result
 instance variantFRecordMatching
   ∷ ( R.RowToList variant vlist
     , R.RowToList record rlist
@@ -83,7 +81,7 @@ class RLFMatch
     (rlist ∷ R.RowList)
     typearg
     result
-  | vlist typearg result → rlist
+  | vlist → rlist typearg result
   , rlist → vlist typearg result
 instance variantFMatchNil
   ∷ RLFMatch R.Nil R.Nil a r

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -12,17 +12,16 @@ module Data.Variant.Internal
   , lookupTag
   , lookupEq
   , lookupOrd
-  , unsafeGet
+  , module Exports
   ) where
 
 import Prelude
 import Control.Alternative (class Alternative, empty)
 import Data.List as L
-import Data.Symbol (SProxy(..), class IsSymbol, reflectSymbol, reifySymbol)
+import Data.Symbol (class IsSymbol, SProxy(SProxy), reflectSymbol)
 import Data.Tuple (Tuple(..))
-import Data.Record as Rec
+import Data.Record.Unsafe (unsafeGet) as Exports
 import Partial.Unsafe (unsafeCrashWith)
-import Unsafe.Coerce (unsafeCoerce)
 import Type.Row as R
 
 data RProxy (r ∷ # Type) = RProxy
@@ -166,15 +165,3 @@ instance contractWithInstance
   contractWith _ _ tag a
     | lookupTag tag (variantTags (RLProxy ∷ RLProxy ltl)) = pure a
     | otherwise = empty
-
-unsafeGet ∷ ∀ a r. String -> Record r -> a
-unsafeGet tag r = unsafeReifyLabelIn tag r (flip Rec.get r)
-
-unsafeReifyLabelIn :: ∀ a r. String -> Record r -> (∀ l r'. RowCons l a r' r => IsSymbol l => SProxy l -> a) -> a
-unsafeReifyLabelIn tag r f = reifySymbol tag noRowCons
-  where
-    coerce :: (∀ l r'. RowCons l a r' r => IsSymbol l => SProxy l -> a)
-           -> {} -> (∀ l. IsSymbol l => SProxy l -> a)
-    coerce = unsafeCoerce
-    noRowCons :: ∀ l. IsSymbol l => SProxy l -> a
-    noRowCons = coerce f {}

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -3,10 +3,10 @@ module Data.Variant.Internal
   , VariantCase
   , class VariantTags, variantTags
   , class Contractable, contractWith
-  , class VRMatching
-  , class RLMatch
-  , class VRFMatching
-  , class RLFMatch
+  , class VariantRecordMatching
+  , class VariantMatchEachCase
+  , class VariantFRecordMatching
+  , class VariantFMatchEachCase
   , lookupTag
   , lookupEq
   , lookupOrd
@@ -30,7 +30,7 @@ data FProxy (a ∷ Type → Type) = FProxy
 -- | Type class that matches a row for a `record` that will eliminate a row for
 -- | a `variant`, producing a `result` of the specified type. Just a wrapper for
 -- | `RLMatch` to convert `RowToList` and vice versa.
-class VRMatching
+class VariantRecordMatching
     (variant ∷ # Type)
     (record ∷ # Type)
     result
@@ -38,27 +38,30 @@ class VRMatching
 instance variantRecordMatching
   ∷ ( R.RowToList variant vlist
     , R.RowToList record rlist
-    , RLMatch vlist rlist result
+    , VariantMatchEachCase vlist rlist result
     , R.ListToRow vlist variant
     , R.ListToRow rlist record )
-  ⇒ VRMatching variant record result
+  ⇒ VariantRecordMatching variant record result
 
 -- | Checks that a `RowList` matches the argument to be given to the function
 -- | in the other `RowList` with the same label, such that it will produce the
 -- | result type.
-class RLMatch
+class VariantMatchEachCase
     (vlist ∷ R.RowList)
     (rlist ∷ R.RowList)
     result
   | vlist → rlist result
   , rlist → vlist result
 instance variantMatchNil
-  ∷ RLMatch R.Nil R.Nil r
+  ∷ VariantMatchEachCase R.Nil R.Nil r
 instance variantMatchCons
-  ∷ RLMatch v r res
-  ⇒ RLMatch (R.Cons sym a v) (R.Cons sym (a → res) r) res
+  ∷ VariantMatchEachCase v r res
+  ⇒ VariantMatchEachCase
+    (R.Cons sym a v)
+    (R.Cons sym (a → res) r)
+    res
 
-class VRFMatching
+class VariantFRecordMatching
     (variant ∷ # Type)
     (record ∷ # Type)
     typearg
@@ -67,15 +70,15 @@ class VRFMatching
 instance variantFRecordMatching
   ∷ ( R.RowToList variant vlist
     , R.RowToList record rlist
-    , RLFMatch vlist rlist typearg result
+    , VariantFMatchEachCase vlist rlist typearg result
     , R.ListToRow vlist variant
     , R.ListToRow rlist record )
-  ⇒ VRFMatching variant record typearg result
+  ⇒ VariantFRecordMatching variant record typearg result
 
 -- | Checks that a `RowList` matches the argument to be given to the function
 -- | in the other `RowList` with the same label, such that it will produce the
 -- | result type.
-class RLFMatch
+class VariantFMatchEachCase
     (vlist ∷ R.RowList)
     (rlist ∷ R.RowList)
     typearg
@@ -83,10 +86,13 @@ class RLFMatch
   | vlist → rlist typearg result
   , rlist → vlist typearg result
 instance variantFMatchNil
-  ∷ RLFMatch R.Nil R.Nil a r
+  ∷ VariantFMatchEachCase R.Nil R.Nil a r
 instance variantFMatchCons
-  ∷ RLFMatch v r a res
-  ⇒ RLFMatch (R.Cons sym (FProxy f) v) (R.Cons sym (f a → res) r) a res
+  ∷ VariantFMatchEachCase v r a res
+  ⇒ VariantFMatchEachCase
+    (R.Cons sym (FProxy f) v)
+    (R.Cons sym (f a → res) r)
+    a res
 
 foreign import data VariantCase ∷ Type
 

--- a/test/Variant.purs
+++ b/test/Variant.purs
@@ -60,9 +60,9 @@ test = do
   let
     match' :: Variant TestVariants -> String
     match' = match
-      { foo: \a -> "foo: " <> show a
-      , bar: \a -> "bar: " <> a
-      , baz: \a -> "baz: " <> show a
+      { foo: \a → "foo: " <> show a
+      , bar: \a → "bar: " <> a
+      , baz: \a → "baz: " <> show a
       }
 
   assert' "match': foo" $ match' foo == "foo: 42"

--- a/test/Variant.purs
+++ b/test/Variant.purs
@@ -3,7 +3,7 @@ module Test.Variant where
 import Prelude
 import Control.Monad.Eff (Eff)
 import Data.Maybe (Maybe(..))
-import Data.Variant (Variant, on, case_, default, inj, prj, SProxy(..))
+import Data.Variant (Variant, on, case_, default, inj, prj, elim, SProxy(..))
 import Test.Assert (assert', ASSERT)
 
 type TestVariants =
@@ -55,3 +55,15 @@ test = do
   assert' "case2: foo" $ case2 foo == "foo: 42"
   assert' "case2: bar" $ case2 bar == "bar: bar"
   assert' "case2: baz" $ case2 baz == "no match"
+
+  let
+    elim' :: Variant TestVariants -> String
+    elim' v = elim v
+      { foo: \a -> "foo: " <> show a
+      , bar: \a -> "bar: " <> a
+      , baz: \a -> "baz: " <> show a
+      }
+
+  assert' "elim': foo" $ elim' foo == "foo: 42"
+  assert' "elim': bar" $ elim' bar == "bar: bar"
+  assert' "elim': baz" $ elim' baz == "baz: true"

--- a/test/Variant.purs
+++ b/test/Variant.purs
@@ -2,10 +2,9 @@ module Test.Variant where
 
 import Prelude
 import Control.Monad.Eff (Eff)
-import Data.Maybe (Maybe(..))
 import Data.List as L
 import Data.Maybe (Maybe(..), isJust)
-import Data.Variant (Variant, on, case_, default, inj, prj, SProxy(..), elim, contract)
+import Data.Variant (Variant, on, case_, default, inj, prj, SProxy(..), match, contract)
 import Test.Assert (assert', ASSERT)
 
 type TestVariants =
@@ -59,16 +58,16 @@ test = do
   assert' "case2: baz" $ case2 baz == "no match"
 
   let
-    elim' :: Variant TestVariants -> String
-    elim' v = elim v
+    match' :: Variant TestVariants -> String
+    match' v = match v
       { foo: \a -> "foo: " <> show a
       , bar: \a -> "bar: " <> a
       , baz: \a -> "baz: " <> show a
       }
 
-  assert' "elim': foo" $ elim' foo == "foo: 42"
-  assert' "elim': bar" $ elim' bar == "bar: bar"
-  assert' "elim': baz" $ elim' baz == "baz: true"
+  assert' "match': foo" $ match' foo == "foo: 42"
+  assert' "match': bar" $ match' bar == "bar: bar"
+  assert' "match': baz" $ match' baz == "baz: true"
 
   assert' "eq: foo" $ (foo ∷ Variant TestVariants) == foo
   assert' "eq: bar" $ (bar ∷ Variant TestVariants) == bar

--- a/test/Variant.purs
+++ b/test/Variant.purs
@@ -59,7 +59,7 @@ test = do
 
   let
     match' :: Variant TestVariants -> String
-    match' v = match v
+    match' = match
       { foo: \a -> "foo: " <> show a
       , bar: \a -> "bar: " <> a
       , baz: \a -> "baz: " <> show a

--- a/test/VariantF.purs
+++ b/test/VariantF.purs
@@ -67,7 +67,7 @@ test = do
 
   let
     match' ∷ VariantF TestVariants Int → String
-    match' = flip match
+    match' = match
       { foo: \a → "foo: " <> show a
       , bar: \a → "bar: " <> show a
       , baz: \a → "baz: " <> show a

--- a/test/VariantF.purs
+++ b/test/VariantF.purs
@@ -4,7 +4,7 @@ import Prelude
 import Control.Monad.Eff (Eff)
 import Data.List as L
 import Data.Either (Either(..))
-import Data.Functor.Variant (VariantF, on, case_, default, inj, prj, SProxy(..), FProxy, contract)
+import Data.Functor.Variant (VariantF, on, case_, default, match, inj, prj, SProxy(..), FProxy, contract)
 import Data.Maybe (Maybe(..), isJust)
 import Data.Tuple (Tuple(..))
 import Test.Assert (assert', ASSERT)
@@ -64,6 +64,18 @@ test = do
     case3 = case_ # on _foo (\a → "foo: " <> show a)
 
   assert' "map" $ case3 (show <$> foo) == "foo: (Just \"42\")"
+
+  let
+    match' ∷ VariantF TestVariants Int → String
+    match' = flip match
+      { foo: \a → "foo: " <> show a
+      , bar: \a → "bar: " <> show a
+      , baz: \a → "baz: " <> show a
+      }
+
+  assert' "match': foo" $ match' foo == "foo: (Just 42)"
+  assert' "match': bar" $ match' bar == "bar: (Tuple \"bar\" 42)"
+  assert' "match': baz" $ match' baz == "baz: (Left \"baz\")"
 
   assert' "contract: pass"
     $ isJust


### PR DESCRIPTION
Okay here's my stab at it.
- The compiler insists that `class VariantRecordElim, class VariantMatch` must be exported – is this true? it seems a bit ugly ...
- I just used `StrMap.lookup`, would you prefer FFI?
- Let me know if you want anything renamed, or if you want the helper classes merged, etc.

And of course typeclass polymorphism doesn't work from inside records, but I can't even begin to think of how to accomplish that. Otherwise it seems to work well!