### PR TITLE
Case struct

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,10 @@
     "purescript-symbols": "^3.0.0",
     "purescript-unsafe-coerce": "^3.0.0",
     "purescript-partial": "^1.2.0",
-    "purescript-maybe": "^3.0.0"
+    "purescript-maybe": "^3.0.0",
+    "purescript-records": "^1.0.0",
+    "purescript-typelevel-prelude": "^2.3.1",
+    "purescript-maps": "^3.4.0"
   },
   "devDependencies": {
     "purescript-console": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "private": true,
   "scripts": {
     "build": "pulp build -- --censor-lib --strict",
+    "ide": "purs ide server",
     "test": "pulp test"
   },
   "devDependencies": {
     "pulp": "^11.0.0",
-    "purescript": "^0.11.4",
+    "purescript": "^0.11.6",
     "purescript-psa": "^0.5.0"
   }
 }

--- a/src/Data/Variant.purs
+++ b/src/Data/Variant.purs
@@ -95,7 +95,7 @@ instance
 
 class Matches (vr ∷ # Type) a (cr ∷ # Type) | vr a → cr, cr → vr a
 
-instance variantRecordElim
+instance matches
   ∷ ( RowToList vr vl
     , RowToList cr cl
     , ToFunc vl a cl

--- a/test/Variant.purs
+++ b/test/Variant.purs
@@ -3,7 +3,7 @@ module Test.Variant where
 import Prelude
 import Control.Monad.Eff (Eff)
 import Data.Maybe (Maybe(..))
-import Data.Variant (Variant, on, case_, default, inj, prj, SProxy(..), match, (##), (:+:))
+import Data.Variant (Variant, on, case_, default, inj, prj, SProxy(..), match, (##), (:+:), mapCase, ($$), variant, downcast)
 import Test.Assert (assert', ASSERT)
 
 type TestVariants =
@@ -45,6 +45,8 @@ test = do
   assert' "foo case" $ match cases foo == "42"
   assert' "bar case" $ match cases bar == "barbar"
   assert' "baz case" $ match cases baz == "TRUE"
+
+  assert' "mapCase" $ "1212" == mapCase (\x → x <> x) cases $$ (downcast $ variant { foo: 12 })
 
   assert' "adhoc cases" $ 132 == foo ## {} :+: { foo: add 90 } :+: { bar: add 12 }
 


### PR DESCRIPTION
+ `O(1)` match
+ Works w/o `SProxy :: SProxy "blablabla"` 
+ Emphasizes duality of variant and record
+ Mappeable case 

I don't think that removing `on|case_|default` is good idea, callbacks might be a bit simpler to understand. 

@natefaubion How does this approach look? If you like it, I'll add same thing for `Data.Functor.Variant`

