### PR TITLE
Reformulated match combinator

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "purescript-maybe": "^3.0.0",
     "purescript-typelevel-prelude": "^2.4.0",
     "purescript-lists": "^4.9.0",
-    "purescript-record": "0.2.0"
+    "purescript-record": "0.2.3"
   },
   "devDependencies": {
     "purescript-console": "^3.0.0",

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -32,8 +32,9 @@ class VariantMatchCases (rl ∷ R.RowList) (vo ∷ # Type) b | rl → vo b
 instance variantMatchCons
   ∷ ( VariantMatchCases rl vo' b
     , RowCons sym a vo' vo
+    , TypeEquals k (a → b)
     )
-  ⇒ VariantMatchCases (R.Cons sym (a → b) rl) vo b
+  ⇒ VariantMatchCases (R.Cons sym k rl) vo b
 
 instance variantMatchNil
   ∷ VariantMatchCases R.Nil () b

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -3,10 +3,8 @@ module Data.Variant.Internal
   , VariantCase
   , class VariantTags, variantTags
   , class Contractable, contractWith
-  , class VariantRecordMatching
-  , class VariantMatchEachCase
-  , class VariantFRecordMatching
-  , class VariantFMatchEachCase
+  , class VariantMatchCases
+  , class VariantFMatchCases
   , lookupTag
   , lookupEq
   , lookupOrd
@@ -19,8 +17,9 @@ import Control.Alternative (class Alternative, empty)
 import Data.List as L
 import Data.Symbol (class IsSymbol, SProxy(SProxy), reflectSymbol)
 import Data.Tuple (Tuple(..))
-import Data.Record.Unsafe (unsafeGet) as Exports
+import Data.Record.Unsafe (unsafeGet, unsafeHas) as Exports
 import Partial.Unsafe (unsafeCrashWith)
+import Type.Equality (class TypeEquals)
 import Type.Row as R
 import Type.Row (RProxy, RLProxy(..))
 import Type.Row (RProxy(..), RLProxy(..)) as Exports
@@ -28,72 +27,28 @@ import Type.Row (RProxy(..), RLProxy(..)) as Exports
 -- | Proxy for a `Functor`.
 data FProxy (a ∷ Type → Type) = FProxy
 
--- | Type class that matches a row for a `record` that will eliminate a row for
--- | a `variant`, producing a `result` of the specified type. Just a wrapper for
--- | `RLMatch` to convert `RowToList` and vice versa.
-class VariantRecordMatching
-    (variant ∷ # Type)
-    (record ∷ # Type)
-    result
-  | → variant record result
-instance variantRecordMatching
-  ∷ ( R.RowToList variant vlist
-    , R.RowToList record rlist
-    , VariantMatchEachCase vlist rlist result
-    , R.ListToRow vlist variant
-    , R.ListToRow rlist record )
-  ⇒ VariantRecordMatching variant record result
+class VariantMatchCases (rl ∷ R.RowList) (vo ∷ # Type) b | rl → vo b
 
--- | Checks that a `RowList` matches the argument to be given to the function
--- | in the other `RowList` with the same label, such that it will produce the
--- | result type.
-class VariantMatchEachCase
-    (vlist ∷ R.RowList)
-    (rlist ∷ R.RowList)
-    result
-  | vlist → rlist result
-  , rlist → vlist result
-instance variantMatchNil
-  ∷ VariantMatchEachCase R.Nil R.Nil r
 instance variantMatchCons
-  ∷ VariantMatchEachCase v r res
-  ⇒ VariantMatchEachCase
-    (R.Cons sym a v)
-    (R.Cons sym (a → res) r)
-    res
+  ∷ ( VariantMatchCases rl vo' b
+    , RowCons sym a vo' vo
+    )
+  ⇒ VariantMatchCases (R.Cons sym (a → b) rl) vo b
 
-class VariantFRecordMatching
-    (variant ∷ # Type)
-    (record ∷ # Type)
-    typearg
-    result
-  | → variant record typearg result
-instance variantFRecordMatching
-  ∷ ( R.RowToList variant vlist
-    , R.RowToList record rlist
-    , VariantFMatchEachCase vlist rlist typearg result
-    , R.ListToRow vlist variant
-    , R.ListToRow rlist record )
-  ⇒ VariantFRecordMatching variant record typearg result
+instance variantMatchNil
+  ∷ VariantMatchCases R.Nil () b
 
--- | Checks that a `RowList` matches the argument to be given to the function
--- | in the other `RowList` with the same label, such that it will produce the
--- | result type.
-class VariantFMatchEachCase
-    (vlist ∷ R.RowList)
-    (rlist ∷ R.RowList)
-    typearg
-    result
-  | vlist → rlist typearg result
-  , rlist → vlist typearg result
-instance variantFMatchNil
-  ∷ VariantFMatchEachCase R.Nil R.Nil a r
+class VariantFMatchCases (rl ∷ R.RowList) (vo ∷ # Type) a b | rl → vo a b
+
 instance variantFMatchCons
-  ∷ VariantFMatchEachCase v r a res
-  ⇒ VariantFMatchEachCase
-    (R.Cons sym (FProxy f) v)
-    (R.Cons sym (f a → res) r)
-    a res
+  ∷ ( VariantFMatchCases rl vo' a b
+    , RowCons sym (FProxy f) vo' vo
+    , TypeEquals k (f a → b)
+    )
+  ⇒ VariantFMatchCases (R.Cons sym k rl) vo a b
+
+instance variantFMatchNil
+  ∷ VariantFMatchCases R.Nil () a b
 
 foreign import data VariantCase ∷ Type
 

--- a/test/Variant.purs
+++ b/test/Variant.purs
@@ -4,7 +4,7 @@ import Prelude
 import Control.Monad.Eff (Eff)
 import Data.List as L
 import Data.Maybe (Maybe(..), isJust)
-import Data.Variant (Variant, on, case_, default, inj, prj, SProxy(..), match, contract)
+import Data.Variant (Variant, on, onMatch, case_, default, inj, prj, SProxy(..), match, contract)
 import Test.Assert (assert', ASSERT)
 
 type TestVariants =
@@ -59,18 +59,30 @@ test = do
 
   let
     match' ∷ Variant TestVariants → String
-    match' = case_
-      # match
-        { foo: \a → "foo: " <> show a
-        , bar: \a → "bar: " <> a
-        }
-      # match
-        { baz: \a → "baz: " <> show a
-        }
+    match' = match
+      { foo: \a → "foo: " <> show a
+      , bar: \a → "bar: " <> a
+      , baz: \a → "baz: " <> show a
+      }
 
   assert' "match: foo" $ match' foo == "foo: 42"
   assert' "match: bar" $ match' bar == "bar: bar"
   assert' "match: baz" $ match' baz == "baz: true"
+
+  let
+    onMatch' ∷ Variant TestVariants → String
+    onMatch' = case_
+      # onMatch
+        { foo: \a → "foo: " <> show a
+        , bar: \a → "bar: " <> a
+        }
+      # onMatch
+        { baz: \a → "baz: " <> show a
+        }
+
+  assert' "onMatch: foo" $ onMatch' foo == "foo: 42"
+  assert' "onMatch: bar" $ onMatch' bar == "bar: bar"
+  assert' "onMatch: baz" $ onMatch' baz == "baz: true"
 
   assert' "eq: foo" $ (foo ∷ Variant TestVariants) == foo
   assert' "eq: bar" $ (bar ∷ Variant TestVariants) == bar

--- a/test/Variant.purs
+++ b/test/Variant.purs
@@ -58,16 +58,19 @@ test = do
   assert' "case2: baz" $ case2 baz == "no match"
 
   let
-    match' :: Variant TestVariants -> String
-    match' = match
-      { foo: \a → "foo: " <> show a
-      , bar: \a → "bar: " <> a
-      , baz: \a → "baz: " <> show a
-      }
+    match' ∷ Variant TestVariants → String
+    match' = case_
+      # match
+        { foo: \a → "foo: " <> show a
+        , bar: \a → "bar: " <> a
+        }
+      # match
+        { baz: \a → "baz: " <> show a
+        }
 
-  assert' "match': foo" $ match' foo == "foo: 42"
-  assert' "match': bar" $ match' bar == "bar: bar"
-  assert' "match': baz" $ match' baz == "baz: true"
+  assert' "match: foo" $ match' foo == "foo: 42"
+  assert' "match: bar" $ match' bar == "bar: bar"
+  assert' "match: baz" $ match' baz == "baz: true"
 
   assert' "eq: foo" $ (foo ∷ Variant TestVariants) == foo
   assert' "eq: bar" $ (bar ∷ Variant TestVariants) == bar

--- a/test/VariantF.purs
+++ b/test/VariantF.purs
@@ -4,7 +4,7 @@ import Prelude
 import Control.Monad.Eff (Eff)
 import Data.List as L
 import Data.Either (Either(..))
-import Data.Functor.Variant (VariantF, on, case_, default, match, inj, prj, SProxy(..), FProxy, contract)
+import Data.Functor.Variant (VariantF, on, onMatch, case_, default, match, inj, prj, SProxy(..), FProxy, contract)
 import Data.Maybe (Maybe(..), isJust)
 import Data.Tuple (Tuple(..))
 import Test.Assert (assert', ASSERT)
@@ -67,18 +67,30 @@ test = do
 
   let
     match' ∷ VariantF TestVariants Int → String
-    match' = case_
-      # match
-        { foo: \a → "foo: " <> show a
-        , baz: \a → "baz: " <> show a
-        }
-      # match
-        { bar: \a → "bar: " <> show a
-        }
+    match' = match
+      { foo: \a → "foo: " <> show a
+      , bar: \a → "bar: " <> show a
+      , baz: \a → "baz: " <> show a
+      }
 
   assert' "match: foo" $ match' foo == "foo: (Just 42)"
   assert' "match: bar" $ match' bar == "bar: (Tuple \"bar\" 42)"
   assert' "match: baz" $ match' baz == "baz: (Left \"baz\")"
+
+  let
+    onMatch' ∷ VariantF TestVariants Int → String
+    onMatch' = case_
+      # onMatch
+        { foo: \a → "foo: " <> show a
+        , baz: \a → "baz: " <> show a
+        }
+      # onMatch
+        { bar: \a → "bar: " <> show a
+        }
+
+  assert' "onMatch: foo" $ onMatch' foo == "foo: (Just 42)"
+  assert' "onMatch: bar" $ onMatch' bar == "bar: (Tuple \"bar\" 42)"
+  assert' "onMatch: baz" $ onMatch' baz == "baz: (Left \"baz\")"
 
   assert' "contract: pass"
     $ isJust

--- a/test/VariantF.purs
+++ b/test/VariantF.purs
@@ -67,15 +67,18 @@ test = do
 
   let
     match' ∷ VariantF TestVariants Int → String
-    match' = match
-      { foo: \a → "foo: " <> show a
-      , bar: \a → "bar: " <> show a
-      , baz: \a → "baz: " <> show a
-      }
+    match' = case_
+      # match
+        { foo: \a → "foo: " <> show a
+        , baz: \a → "baz: " <> show a
+        }
+      # match
+        { bar: \a → "bar: " <> show a
+        }
 
-  assert' "match': foo" $ match' foo == "foo: (Just 42)"
-  assert' "match': bar" $ match' bar == "bar: (Tuple \"bar\" 42)"
-  assert' "match': baz" $ match' baz == "baz: (Left \"baz\")"
+  assert' "match: foo" $ match' foo == "foo: (Just 42)"
+  assert' "match: bar" $ match' bar == "bar: (Tuple \"bar\" 42)"
+  assert' "match: baz" $ match' baz == "baz: (Left \"baz\")"
 
   assert' "contract: pass"
     $ isJust


### PR DESCRIPTION
@MonoidMusician @cryogenian I'd like to know what you think of this formulation. I wanted `match` to support partial matches so it can be used with `default`. This seems to have very good inference properties because it's determined completely be the shape of the case record. The class walks the `RowList` and builds up an expected `Variant` shape based on the functions in the record. It then takes the `Union` of that to find the leftover unmatched cases. It requires much less type-level machinery compared to the old approach.