### PR TITLE
Work on mapping variant cases

### DIFF
--- a/src/Data/Functor/Variant.purs
+++ b/src/Data/Functor/Variant.purs
@@ -37,7 +37,7 @@ import Data.List as L
 import Data.Symbol (class IsSymbol, reflectSymbol)
 import Data.Traversable as TF
 import Data.Variant.Internal (class Contractable, class VariantFMatchCases, class VariantFMapCases) as Exports
-import Data.Variant.Internal (class Contractable, class VariantFMapCases, class VariantFMatchCases, class VariantFTravCases, class VariantTags, VariantFCase, VariantCase, contractWith, lookup, unsafeGet, unsafeHas, variantTags)
+import Data.Variant.Internal (class Contractable, class VariantFMapCases, class VariantFMatchCases, class VariantFTraverseCases, class VariantTags, VariantFCase, VariantCase, contractWith, lookup, unsafeGet, unsafeHas, variantTags)
 import Partial.Unsafe (unsafeCrashWith)
 import Prim.Row as R
 import Prim.RowList as RL
@@ -326,7 +326,7 @@ traverseOne p f = on p (map (inj p) <<< f)
 traverseSome
   ∷ ∀ r rl rlo ri ro r1 r2 r3 r4 a b m
   . RL.RowToList r rl
-  ⇒ VariantFTravCases m rl ri ro a b
+  ⇒ VariantFTraverseCases m rl ri ro a b
   ⇒ RL.RowToList ro rlo
   ⇒ VariantTags rlo
   ⇒ VariantFMaps rlo
@@ -359,7 +359,7 @@ traverseSome r k v =
   coerceR = unsafeCoerce
 
 -- | Traverse over some labels (with access to the containers) and use
--- | `travers f` for the rest (just changing the index type).
+-- | `traverse f` for the rest (just changing the index type).
 -- |
 -- | `traverse r f` is like `(traverse f >>> expand) # traverseSome r` but with
 -- | a more easily solved constraint (i.e. it can be solved once the type of
@@ -367,7 +367,7 @@ traverseSome r k v =
 traverse
   ∷ ∀ r rl rlo ri ro r1 r2 r3 a b m
   . RL.RowToList r rl
-  ⇒ VariantFTravCases m rl ri ro a b
+  ⇒ VariantFTraverseCases m rl ri ro a b
   ⇒ RL.RowToList ro rlo
   ⇒ VariantTags rlo
   ⇒ VariantFMaps rlo

--- a/src/Data/Functor/Variant.purs
+++ b/src/Data/Functor/Variant.purs
@@ -9,6 +9,8 @@ module Data.Functor.Variant
   , default
   , overMatch
   , expandOverMatch
+  , travMatch
+  , expandTravMatch
   , expand
   , contract
   , UnvariantF(..)

--- a/src/Data/Functor/Variant.purs
+++ b/src/Data/Functor/Variant.purs
@@ -30,8 +30,8 @@ import Data.List as L
 import Data.Symbol (SProxy(..)) as Exports
 import Data.Symbol (SProxy(..), class IsSymbol, reflectSymbol)
 import Data.Traversable as TF
-import Data.Variant.Internal (class Contractable, FProxy(..), class VariantFMatchCases) as Exports
-import Data.Variant.Internal (class Contractable, class VariantFMatchCases, class VariantTags, FProxy, RLProxy(..), RProxy(..), VariantFCase, VariantCase, contractWith, lookup, unsafeGet, unsafeHas, variantTags)
+import Data.Variant.Internal (class Contractable, FProxy(..), class VariantFMatchCases, class VariantFMapCases) as Exports
+import Data.Variant.Internal (class Contractable, class VariantFMatchCases, class VariantFMapCases, class VariantTags, FProxy, RLProxy(..), RProxy(..), VariantFCase, VariantCase, contractWith, lookup, unsafeGet, unsafeHas, variantTags)
 import Partial.Unsafe (unsafeCrashWith)
 import Type.Equality (class TypeEquals)
 import Type.Proxy (Proxy(..))
@@ -210,6 +210,53 @@ onMatch r k v =
 
   coerceR ∷ VariantF r3 a → VariantF r2 a
   coerceR = unsafeCoerce
+
+{-
+mapSome
+  ∷ ∀ r rl ri ro r1 r2 r3 r4 a b
+  . R.RowToList r rl
+  ⇒ VariantFMapCases rl ri ro a b
+  ⇒ R.Union ri r2 r1
+  ⇒ R.Union ro r4 r3
+  ⇒ Record r
+  → (VariantF r2 a → VariantF r3 b)
+  → VariantF r1 a
+  → VariantF r3 b
+mapSome r k v =
+  case coerceV v of
+    VariantFRep v' | unsafeHas v'.type r →
+      coerceV' (VariantFRep { type: v'.type, map: ?help, value: unsafeGet v'.type r v'.value })
+    _ → k (coerceR v)
+
+  where
+  coerceV ∷ ∀ f. VariantF r1 a → VariantFRep f a
+  coerceV = unsafeCoerce
+
+  coerceV' ∷ ∀ g. VariantFRep g b → VariantF r3 b
+  coerceV' = unsafeCoerce
+
+  coerceR ∷ VariantF r1 a → VariantF r2 a
+  coerceR = unsafeCoerce
+
+mapAll
+  ∷ ∀ r rl ri ro
+  . R.RowToList r rl
+  ⇒ VariantFMapCases rl ri ro a b
+  ⇒ Record r
+  → VariantF ri a
+  → VariantF ro b
+mapAll r v =
+  case coerceV v of
+    VariantFRep v' →
+      coerceV' (VariantFRep { type: v'.type, map: ?help, value: unsafeGet v'.type r v'.value })
+
+  where
+  coerceV ∷ ∀ x. VariantF ri a → VariantFRep x
+  coerceV = unsafeCoerce
+
+  coerceV' ∷ ∀ x. VariantFRep x → VariantF ro b
+  coerceV' = unsafeCoerce
+-}
 
 -- | Combinator for exhaustive pattern matching.
 -- | ```purescript

--- a/src/Data/Functor/Variant.purs
+++ b/src/Data/Functor/Variant.purs
@@ -222,6 +222,8 @@ onMatch r k v =
   coerceR ∷ VariantF r3 a → VariantF r2 a
   coerceR = unsafeCoerce
 
+-- | Map over one case of a variant, putting the result back at the same label,
+-- | with a fallback function to handle the remaining cases.
 over
   ∷ ∀ sym f g a b r1 r2 r3 r4
   . R.Cons sym f r1 r2
@@ -235,6 +237,10 @@ over
   → VariantF r3 b
 over p f = on p (inj p <<< f)
 
+-- | Map over several cases of a variant using a `Record` containing functions
+-- | for each case. Each case gets put back at the same label it was matched
+-- | at, i.e. its label in the record. Labels not found in the record are
+-- | handled using the fallback function.
 overMatch
   ∷ ∀ r rl rlo ri ro r1 r2 r3 r4 a b
   . RL.RowToList r rl
@@ -288,6 +294,8 @@ expandOverMatch
 expandOverMatch r k = overMatch r (map k >>> unsafeExpand) where
   unsafeExpand = unsafeCoerce ∷ VariantF r2 b → VariantF r3 b
 
+-- | Traverse over one case of a variant (in a functorial/monadic context `m`),
+-- | putting the result back at the same label, with a fallback function.
 trav
   ∷ ∀ sym f g a b r1 r2 r3 r4 m
   . R.Cons sym f r1 r2
@@ -302,6 +310,10 @@ trav
   → m (VariantF r3 b)
 trav p f = on p (map (inj p) <<< f)
 
+-- | Traverse over several cases of a variant using a `Record` containing
+-- | traversals. Each case gets put back at the same label it was matched
+-- | at, i.e. its label in the record. Labels not found in the record are
+-- | handled using the fallback function.
 travMatch
   ∷ ∀ r rl rlo ri ro r1 r2 r3 r4 a b m
   . RL.RowToList r rl
@@ -337,6 +349,7 @@ travMatch r k v =
   coerceR ∷ VariantF r1 a → VariantF r2 a
   coerceR = unsafeCoerce
 
+-- | Expand after `travMatch`.
 expandTravMatch
   ∷ ∀ r rl rlo ri ro r1 r2 r3 r4 a b m
   . RL.RowToList r rl

--- a/src/Data/Variant.purs
+++ b/src/Data/Variant.purs
@@ -107,15 +107,15 @@ on p f g r =
 -- |
 -- | ```purescript
 -- | onMatch
--- |   { foo: \foo → "Foo: " <> foo
--- |   , bar: \bar → "Bar: " <> bar
+-- |   { foo: \foo -> "Foo: " <> foo
+-- |   , bar: \bar -> "Bar: " <> bar
 -- |   }
 -- | ````
 -- |
 -- | Polymorphic functions in records (such as `show` or `id`) can lead
 -- | to inference issues if not all polymorphic variables are specified
 -- | in usage. When in doubt, label methods with specific types, such as
--- | `show :: Int → String`, or give the whole record an appropriate type.
+-- | `show :: Int -> String`, or give the whole record an appropriate type.
 onMatch
   ∷ ∀ rl r r1 r2 r3 b
   . RL.RowToList r rl
@@ -255,7 +255,7 @@ expandTravMatch r = travMatch r (pure <<< unsafeExpand) where
 
 -- | Combinator for exhaustive pattern matching.
 -- | ```purescript
--- | caseFn :: Variant (foo :: Int, bar :: String, baz :: Boolean) → String
+-- | caseFn :: Variant (foo :: Int, bar :: String, baz :: Boolean) -> String
 -- | caseFn = case_
 -- |  # on (Proxy :: Proxy "foo") (\foo -> "Foo: " <> show foo)
 -- |  # on (Proxy :: Proxy "bar") (\bar -> "Bar: " <> bar)
@@ -267,11 +267,11 @@ case_ r = unsafeCrashWith case unsafeCoerce r of
 
 -- | Combinator for exhaustive pattern matching using an `onMatch` case record.
 -- | ```purescript
--- | matchFn :: Variant (foo :: Int, bar :: String, baz :: Boolean) → String
+-- | matchFn :: Variant (foo :: Int, bar :: String, baz :: Boolean) -> String
 -- | matchFn = match
--- |   { foo: \foo → "Foo: " <> show foo
--- |   , bar: \bar → "Bar: " <> bar
--- |   , baz: \baz → "Baz: " <> show baz
+-- |   { foo: \foo -> "Foo: " <> show foo
+-- |   , bar: \bar -> "Bar: " <> bar
+-- |   , baz: \baz -> "Baz: " <> show baz
 -- |   }
 -- | ```
 match
@@ -286,7 +286,7 @@ match r = case_ # onMatch r
 
 -- | Combinator for partial matching with a default value in case of failure.
 -- | ```purescript
--- | caseFn :: forall r. Variant (foo :: Int, bar :: String | r) → String
+-- | caseFn :: forall r. Variant (foo :: Int, bar :: String | r) -> String
 -- | caseFn = default "No match"
 -- |  # on (Proxy :: Proxy "foo") (\foo -> "Foo: " <> show foo)
 -- |  # on (Proxy :: Proxy "bar") (\bar -> "Bar: " <> bar)

--- a/src/Data/Variant.purs
+++ b/src/Data/Variant.purs
@@ -137,7 +137,8 @@ onMatch r k v =
   coerceR ∷ Variant r3 → Variant r2
   coerceR = unsafeCoerce
 
--- | Map over one case of a variant, putting the result back at the same label.
+-- | Map over one case of a variant, putting the result back at the same label,
+-- | with a fallback function to handle the remaining cases.
 over
   ∷ ∀ sym a b r1 r2 r3 r4
   . IsSymbol sym
@@ -152,7 +153,8 @@ over p f = on p (inj p <<< f)
 
 -- | Map over several cases of a variant using a `Record` containing functions
 -- | for each case. Each case gets put back at the same label it was matched
--- | at, i.e. its label in the record.
+-- | at, i.e. its label in the record. Labels not found in the record are
+-- | handled using the fallback function.
 overMatch
   ∷ ∀ r rl ri ro r1 r2 r3 r4
   . RL.RowToList r rl
@@ -194,7 +196,8 @@ expandOverMatch
 expandOverMatch r = overMatch r unsafeExpand where
   unsafeExpand = unsafeCoerce ∷ Variant r2 → Variant r3
 
--- | Traverse over one case of a variant, putting the result back at the same label.
+-- | Traverse over one case of a variant (in a functorial/monadic context `m`),
+-- | putting the result back at the same label, with a fallback function.
 trav
   ∷ ∀ sym a b r1 r2 r3 r4 m
   . IsSymbol sym
@@ -208,9 +211,10 @@ trav
   → m (Variant r3)
 trav p f = on p (map (inj p) <<< f)
 
--- | Map over several cases of a variant using a `Record` containing functions
--- | for each case. Each case gets put back at the same label it was matched
--- | at, i.e. its label in the record.
+-- | Traverse over several cases of a variant using a `Record` containing
+-- | traversals. Each case gets put back at the same label it was matched
+-- | at, i.e. its label in the record. Labels not found in the record are
+-- | handled using the fallback function.
 travMatch
   ∷ ∀ r rl ri ro r1 r2 r3 r4 m
   . RL.RowToList r rl
@@ -239,6 +243,7 @@ travMatch r k v =
   coerceR ∷ Variant r1 → Variant r2
   coerceR = unsafeCoerce
 
+-- | Expand after `travMatch`.
 expandTravMatch
   ∷ ∀ r rl ri ro r1 r2 r3 r4 m
   . RL.RowToList r rl

--- a/src/Data/Variant.purs
+++ b/src/Data/Variant.purs
@@ -34,8 +34,8 @@ import Data.Enum (class Enum, pred, succ, class BoundedEnum, Cardinality(..), fr
 import Data.List as L
 import Data.Maybe (Maybe)
 import Data.Symbol (class IsSymbol, reflectSymbol)
-import Data.Variant.Internal (class Contractable, class VariantMapCases, class VariantMatchCases) as Exports
-import Data.Variant.Internal (class Contractable, class VariantMapCases, class VariantMatchCases, class VariantTags, class VariantTravCases, BoundedDict, BoundedEnumDict, VariantCase, VariantRep(..), contractWith, lookup, lookupCardinality, lookupEq, lookupFirst, lookupFromEnum, lookupLast, lookupOrd, lookupPred, lookupSucc, lookupToEnum, unsafeGet, unsafeHas, variantTags)
+import Data.Variant.Internal (class Contractable, class VariantMapCases, class VariantMatchCases, class VariantTraverseCases) as Exports
+import Data.Variant.Internal (class Contractable, class VariantMapCases, class VariantMatchCases, class VariantTags, class VariantTraverseCases, BoundedDict, BoundedEnumDict, VariantCase, VariantRep(..), contractWith, lookup, lookupCardinality, lookupEq, lookupFirst, lookupFromEnum, lookupLast, lookupOrd, lookupPred, lookupSucc, lookupToEnum, unsafeGet, unsafeHas, variantTags)
 import Partial.Unsafe (unsafeCrashWith)
 import Prim.Row as R
 import Prim.RowList as RL
@@ -224,7 +224,7 @@ traverseOne p f = on p (map (inj p) <<< f)
 traverseSome
   ∷ ∀ r rl ri ro r1 r2 r3 r4 m
   . RL.RowToList r rl
-  ⇒ VariantTravCases m rl ri ro
+  ⇒ VariantTraverseCases m rl ri ro
   ⇒ R.Union ri r2 r1
   ⇒ R.Union ro r4 r3
   ⇒ Functor m
@@ -254,7 +254,7 @@ traverseSome r k v =
 traverse
   ∷ ∀ r rl ri ro r1 r2 r3 m
   . RL.RowToList r rl
-  ⇒ VariantTravCases m rl ri ro
+  ⇒ VariantTraverseCases m rl ri ro
   ⇒ R.Union ri r2 r1
   ⇒ R.Union ro r2 r3 -- this is "backwards" for `expand`, but still safe
   ⇒ Applicative m

--- a/src/Data/Variant.purs
+++ b/src/Data/Variant.purs
@@ -359,10 +359,10 @@ unvariant v = case (unsafeCoerce v ∷ VariantRep Unit) of
   coerce = unsafeCoerce
 
 -- | Reconstructs a Variant given an Unvariant eliminator.
-revariant ∷ ∀ r. Unvariant r → Variant r
+revariant ∷ ∀ r. Unvariant r -> Variant r
 revariant (Unvariant f) = f inj
 
-class VariantEqs :: RL.RowList Type → Constraint
+class VariantEqs :: RL.RowList Type -> Constraint
 class VariantEqs rl where
   variantEqs ∷ forall proxy. proxy rl → L.List (VariantCase → VariantCase → Boolean)
 
@@ -386,7 +386,7 @@ instance eqVariant ∷ (RL.RowToList r rl, VariantTags rl, VariantEqs rl) ⇒ Eq
     in
       lookupEq tags eqs c1 c2
 
-class VariantBounded :: RL.RowList Type → Constraint
+class VariantBounded :: RL.RowList Type -> Constraint
 class VariantBounded rl where
   variantBounded ∷ forall proxy. proxy rl → L.List (BoundedDict VariantCase)
 
@@ -422,7 +422,7 @@ instance boundedVariant ∷ (RL.RowToList r rl, VariantTags rl, VariantEqs rl, V
     in
       coerce $ VariantRep $ lookupFirst "bottom" _.bottom tags dicts
 
-class VariantBoundedEnums :: RL.RowList Type → Constraint
+class VariantBoundedEnums :: RL.RowList Type -> Constraint
 class VariantBounded rl ⇐ VariantBoundedEnums rl where
   variantBoundedEnums ∷ forall proxy. proxy rl → L.List (BoundedEnumDict VariantCase)
 
@@ -494,7 +494,7 @@ instance boundedEnumVariant ∷ (RL.RowToList r rl, VariantTags rl, VariantEqs r
     in
       coerceV $ lookupToEnum n tags dicts
 
-class VariantOrds :: RL.RowList Type → Constraint
+class VariantOrds :: RL.RowList Type -> Constraint
 class VariantOrds rl where
   variantOrds ∷ forall proxy. proxy rl → L.List (VariantCase → VariantCase → Ordering)
 
@@ -518,7 +518,7 @@ instance ordVariant ∷ (RL.RowToList r rl, VariantTags rl, VariantEqs rl, Varia
     in
       lookupOrd tags ords c1 c2
 
-class VariantShows :: RL.RowList Type → Constraint
+class VariantShows :: RL.RowList Type -> Constraint
 class VariantShows rl where
   variantShows ∷ forall proxy. proxy rl → L.List (VariantCase → String)
 

--- a/src/Data/Variant.purs
+++ b/src/Data/Variant.purs
@@ -7,6 +7,9 @@ module Data.Variant
   , case_
   , match
   , default
+  , mapSome
+  , mapSomeExpand
+  , mapAll
   , expand
   , contract
   , Unvariant(..)
@@ -154,6 +157,32 @@ mapSome r k v =
   coerceV' = unsafeCoerce
 
   coerceR ∷ Variant r1 → Variant r2
+  coerceR = unsafeCoerce
+
+mapSomeExpand
+  ∷ ∀ r rl ri ro r1 r2 r3 r4
+  . R.RowToList r rl
+  ⇒ VariantMapCases rl ri ro
+  ⇒ R.Union ri r2 r1
+  ⇒ R.Union ro r4 r3
+  ⇒ R.Union ro r2 r3
+  ⇒ Record r
+  → Variant r1
+  → Variant r3
+mapSomeExpand r v =
+  case coerceV v of
+    VariantRep v' | unsafeHas v'.type r →
+      coerceV' (VariantRep { type: v'.type, value: unsafeGet v'.type r v'.value })
+    _ → coerceR v
+
+  where
+  coerceV ∷ ∀ a. Variant r1 → VariantRep a
+  coerceV = unsafeCoerce
+
+  coerceV' ∷ ∀ a. VariantRep a → Variant r3
+  coerceV' = unsafeCoerce
+
+  coerceR ∷ Variant r1 → Variant r3
   coerceR = unsafeCoerce
 
 mapAll

--- a/src/Data/Variant.purs
+++ b/src/Data/Variant.purs
@@ -9,6 +9,8 @@ module Data.Variant
   , default
   , overMatch
   , expandOverMatch
+  , travMatch
+  , expandTravMatch
   , expand
   , contract
   , Unvariant(..)
@@ -234,7 +236,7 @@ travMatch r k v =
   coerceR ∷ Variant r1 → Variant r2
   coerceR = unsafeCoerce
 
-travOverMatch
+expandTravMatch
   ∷ ∀ r rl ri ro r1 r2 r3 r4 m
   . R.RowToList r rl
   ⇒ VariantTravCases m rl ri ro
@@ -245,7 +247,7 @@ travOverMatch
   ⇒ Record r
   → Variant r1
   → m (Variant r3)
-travOverMatch r = travMatch r (pure <<< unsafeExpand) where
+expandTravMatch r = travMatch r (pure <<< unsafeExpand) where
   unsafeExpand = unsafeCoerce ∷ Variant r2 → Variant r3
 
 -- | Combinator for exhaustive pattern matching.

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -9,6 +9,8 @@ module Data.Variant.Internal
   , class VariantFMatchCases
   , class VariantMapCases
   , class VariantFMapCases
+  , class VariantTravCases
+  , class VariantFTravCases
   , lookup
   , lookupTag
   , lookupEq
@@ -101,6 +103,36 @@ instance variantFMapCons
 
 instance variantFMapNil
   ∷ VariantFMapCases R.Nil () () a b
+
+class VariantTravCases (m ∷ Type → Type) (rl ∷ R.RowList)
+  (ri ∷ # Type) (ro ∷ # Type)
+  | rl → ri ro
+
+instance variantTravCons
+  ∷ ( R.Cons sym a ri' ri
+    , R.Cons sym b ro' ro
+    , VariantTravCases m rl ri' ro'
+    , TypeEquals k (a → m b)
+    )
+  ⇒ VariantTravCases m (R.Cons sym k rl) ri ro
+
+instance variantTravNil
+  ∷ VariantTravCases m R.Nil () ()
+
+class VariantFTravCases (m ∷ Type → Type) (rl ∷ R.RowList)
+  (ri ∷ # Type) (ro ∷ # Type) (a ∷ Type) (b ∷ Type)
+  | rl → ri ro
+
+instance variantFTravCons
+  ∷ ( R.Cons sym (FProxy f) ri' ri
+    , R.Cons sym (FProxy g) ro' ro
+    , VariantFTravCases m rl ri' ro' a b
+    , TypeEquals k (f a → m (g b))
+    )
+  ⇒ VariantFTravCases m (R.Cons sym k rl) ri ro a b
+
+instance variantFTravNil
+  ∷ VariantFTravCases m R.Nil () () a b
 
 foreign import data VariantCase ∷ Type
 

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -88,7 +88,7 @@ instance variantMapNil
   ∷ VariantMapCases R.Nil () ()
 
 class VariantFMapCases (rl ∷ R.RowList)
-  (ri ∷ # Type) (ro ∷ # Type) (a :: Type) (b :: Type)
+  (ri ∷ # Type) (ro ∷ # Type) (a ∷ Type) (b ∷ Type)
   | rl → ri ro
 
 instance variantFMapCons
@@ -100,7 +100,7 @@ instance variantFMapCons
   ⇒ VariantFMapCases (R.Cons sym k rl) ri ro a b
 
 instance variantFMapNil
-  ∷ VariantFMapCases R.Nil ri ro a b
+  ∷ VariantFMapCases R.Nil () () a b
 
 foreign import data VariantCase ∷ Type
 

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -8,8 +8,8 @@ module Data.Variant.Internal
   , class VariantFMatchCases
   , class VariantMapCases
   , class VariantFMapCases
-  , class VariantTravCases
-  , class VariantFTravCases
+  , class VariantTraverseCases
+  , class VariantFTraverseCases
   , lookup
   , lookupTag
   , lookupEq
@@ -102,35 +102,35 @@ instance variantFMapCons
 instance variantFMapNil
   ∷ VariantFMapCases RL.Nil () () a b
 
-class VariantTravCases (m ∷ Type → Type) (rl ∷ RL.RowList Type)
+class VariantTraverseCases (m ∷ Type → Type) (rl ∷ RL.RowList Type)
   (ri ∷ Row Type) (ro ∷ Row Type)
   | rl → ri ro
 
 instance variantTravCons
   ∷ ( R.Cons sym a ri' ri
     , R.Cons sym b ro' ro
-    , VariantTravCases m rl ri' ro'
+    , VariantTraverseCases m rl ri' ro'
     , TypeEquals k (a → m b)
     )
-  ⇒ VariantTravCases m (RL.Cons sym k rl) ri ro
+  ⇒ VariantTraverseCases m (RL.Cons sym k rl) ri ro
 
 instance variantTravNil
-  ∷ VariantTravCases m RL.Nil () ()
+  ∷ VariantTraverseCases m RL.Nil () ()
 
-class VariantFTravCases (m ∷ Type → Type) (rl ∷ RL.RowList Type)
+class VariantFTraverseCases (m ∷ Type → Type) (rl ∷ RL.RowList Type)
   (ri ∷ Row (Type → Type)) (ro ∷ Row (Type → Type)) (a ∷ Type) (b ∷ Type)
   | rl → ri ro
 
 instance variantFTravCons
   ∷ ( R.Cons sym f ri' ri
     , R.Cons sym g ro' ro
-    , VariantFTravCases m rl ri' ro' a b
+    , VariantFTraverseCases m rl ri' ro' a b
     , TypeEquals k (f a → m (g b))
     )
-  ⇒ VariantFTravCases m (RL.Cons sym k rl) ri ro a b
+  ⇒ VariantFTraverseCases m (RL.Cons sym k rl) ri ro a b
 
 instance variantFTravNil
-  ∷ VariantFTravCases m RL.Nil () () a b
+  ∷ VariantFTraverseCases m RL.Nil () () a b
 
 foreign import data VariantCase ∷ Type
 

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -46,7 +46,7 @@ newtype VariantRep a = VariantRep
   , value ∷ a
   }
 
-class VariantMatchCases :: RL.RowList Type → Row Type → Type → Constraint
+class VariantMatchCases :: RL.RowList Type -> Row Type -> Type -> Constraint
 class VariantMatchCases rl vo b | rl → vo b
 
 instance variantMatchCons
@@ -59,7 +59,7 @@ instance variantMatchCons
 instance variantMatchNil
   ∷ VariantMatchCases RL.Nil () b
 
-class VariantFMatchCases :: RL.RowList Type → Row (Type → Type) → Type → Type → Constraint
+class VariantFMatchCases :: RL.RowList Type -> Row (Type -> Type) -> Type -> Type -> Constraint
 class VariantFMatchCases rl vo a b | rl → vo a b
 
 instance variantFMatchCons
@@ -136,7 +136,7 @@ foreign import data VariantCase ∷ Type
 
 foreign import data VariantFCase ∷ Type → Type
 
-class VariantTags :: forall k. RL.RowList k → Constraint
+class VariantTags :: forall k. RL.RowList k -> Constraint
 class VariantTags rl where
   variantTags ∷ forall proxy. proxy rl → L.List String
 
@@ -308,7 +308,7 @@ lookupToEnum = go
       | otherwise → go (ix - d.cardinality) ts ds
     _, _ → Nothing
 
-class Contractable :: forall k. Row k → Row k → Constraint
+class Contractable :: forall k. Row k -> Row k -> Constraint
 class Contractable gt lt where
   contractWith ∷ ∀ proxy1 proxy2 f a. Alternative f ⇒ proxy1 gt → proxy2 lt → String → a → f a
 

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -7,6 +7,8 @@ module Data.Variant.Internal
   , class Contractable, contractWith
   , class VariantMatchCases
   , class VariantFMatchCases
+  , class VariantMapCases
+  , class VariantFMapCases
   , lookup
   , lookupTag
   , lookupEq
@@ -69,6 +71,36 @@ instance variantFMatchCons
 
 instance variantFMatchNil
   ∷ VariantFMatchCases R.Nil () a b
+
+class VariantMapCases (rl ∷ R.RowList)
+  (ri ∷ # Type) (ro ∷ # Type)
+  | rl → ri ro
+
+instance variantMapCons
+  ∷ ( R.Cons sym a ri' ri
+    , R.Cons sym b ro' ro
+    , VariantMapCases rl ri' ro'
+    , TypeEquals k (a → b)
+    )
+  ⇒ VariantMapCases (R.Cons sym k rl) ri ro
+
+instance variantMapNil
+  ∷ VariantMapCases R.Nil () ()
+
+class VariantFMapCases (rl ∷ R.RowList)
+  (ri ∷ # Type) (ro ∷ # Type) (a :: Type) (b :: Type)
+  | rl → ri ro
+
+instance variantFMapCons
+  ∷ ( R.Cons sym (FProxy f) ri' ri
+    , R.Cons sym (FProxy g) ro' ro
+    , VariantFMapCases rl ri' ro' a b
+    , TypeEquals k (f a → g b)
+    )
+  ⇒ VariantFMapCases (R.Cons sym k rl) ri ro a b
+
+instance variantFMapNil
+  ∷ VariantFMapCases R.Nil ri ro a b
 
 foreign import data VariantCase ∷ Type
 

--- a/test/Variant.purs
+++ b/test/Variant.purs
@@ -5,7 +5,7 @@ import Prelude
 import Data.List as L
 import Data.Maybe (Maybe(..), isJust)
 import Data.Symbol (reflectSymbol)
-import Data.Variant (Variant, on, onMatch, case_, default, expand, expandOverMatch, inj, prj, match, overMatch, contract, Unvariant(..), unvariant, revariant)
+import Data.Variant (Variant, on, onMatch, case_, default, expand, inj, prj, match, over, overSome, contract, Unvariant(..), unvariant, revariant)
 import Effect (Effect)
 import Record.Builder (build, modify, Builder)
 import Test.Assert (assert')
@@ -98,16 +98,16 @@ test = do
   assert' "match: baz" $ match' baz == "baz: true"
 
   let
-    overMatch' ∷ Variant TestVariants → Variant TestVariants'
-    overMatch' = overMatch
+    overSome' ∷ Variant TestVariants → Variant TestVariants'
+    overSome' = overSome
       { foo: \a → show a
       , baz: \a → show a
       } expand
 
-    expandOverMatch' ∷ forall r.
+    over' ∷ forall r.
       Variant ( foo ∷ Int, baz ∷ Boolean | r ) →
       Variant ( foo ∷ String, baz ∷ String | r )
-    expandOverMatch' = expandOverMatch
+    over' = over
       { foo: \a → show a
       , baz: \a → show a
       }
@@ -122,13 +122,13 @@ test = do
         { baz: \a → "baz: " <> a
         }
 
-  assert' "onMatch overMatch: foo" $ onMatch' (overMatch' foo) == "foo: 42"
-  assert' "onMatch overMatch: bar" $ onMatch' (overMatch' bar) == "bar: bar"
-  assert' "onMatch overMatch: baz" $ onMatch' (overMatch' baz) == "baz: true"
+  assert' "onMatch overSome: foo" $ onMatch' (overSome' foo) == "foo: 42"
+  assert' "onMatch overSome: bar" $ onMatch' (overSome' bar) == "bar: bar"
+  assert' "onMatch overSome: baz" $ onMatch' (overSome' baz) == "baz: true"
 
-  assert' "onMatch expandOverMatch: foo" $ onMatch' (expandOverMatch' foo) == "foo: 42"
-  assert' "onMatch expandOverMatch: bar" $ onMatch' (expandOverMatch' bar) == "bar: bar"
-  assert' "onMatch expandOverMatch: baz" $ onMatch' (expandOverMatch' baz) == "baz: true"
+  assert' "onMatch over: foo" $ onMatch' (over' foo) == "foo: 42"
+  assert' "onMatch over: bar" $ onMatch' (over' bar) == "bar: bar"
+  assert' "onMatch over: baz" $ onMatch' (over' baz) == "baz: true"
 
   assert' "eq: foo" $ (foo ∷ Variant TestVariants) == foo
   assert' "eq: bar" $ (bar ∷ Variant TestVariants) == bar

--- a/test/Variant.purs
+++ b/test/Variant.purs
@@ -5,7 +5,7 @@ import Prelude
 import Data.List as L
 import Data.Maybe (Maybe(..), isJust)
 import Data.Symbol (reflectSymbol)
-import Data.Variant (SProxy(..), Unvariant(..), Variant, case_, contract, default, expand, inj, mapAll, mapSome, mapSomeExpand, match, on, onMatch, prj, revariant, unvariant)
+import Data.Variant (SProxy(..), Unvariant(..), Variant, case_, contract, default, expand, inj, overMatch, expandOverMatch, match, on, onMatch, prj, revariant, unvariant)
 import Effect (Effect)
 import Record.Builder (build, modify, Builder)
 import Test.Assert (assert')
@@ -97,25 +97,18 @@ test = do
   assert' "match: baz" $ match' baz == "baz: true"
 
   let
-    mapSome' ∷ Variant TestVariants → Variant TestVariants'
-    mapSome' = mapSome
+    overMatch' ∷ Variant TestVariants → Variant TestVariants'
+    overMatch' = overMatch
       { foo: \a → show a
       , baz: \a → show a
       } expand
 
-    mapSomeExpand' ∷ forall r.
+    expandOverMatch' ∷ forall r.
       Variant ( foo ∷ Int, baz ∷ Boolean | r ) →
       Variant ( foo ∷ String, baz ∷ String | r )
-    mapSomeExpand' = mapSomeExpand
+    expandOverMatch' = expandOverMatch
       { foo: \a → show a
       , baz: \a → show a
-      }
-
-    mapAll' ∷ Variant TestVariants → Variant TestVariants'
-    mapAll' = mapAll
-      { foo: identity show
-      , bar: identity identity
-      , baz: identity show
       }
 
     onMatch' ∷ Variant TestVariants' → String
@@ -128,17 +121,13 @@ test = do
         { baz: \a → "baz: " <> a
         }
 
-  assert' "onMatch mapSome: foo" $ onMatch' (mapSome' foo) == "foo: 42"
-  assert' "onMatch mapSome: bar" $ onMatch' (mapSome' bar) == "bar: bar"
-  assert' "onMatch mapSome: baz" $ onMatch' (mapSome' baz) == "baz: true"
+  assert' "onMatch overMatch: foo" $ onMatch' (overMatch' foo) == "foo: 42"
+  assert' "onMatch overMatch: bar" $ onMatch' (overMatch' bar) == "bar: bar"
+  assert' "onMatch overMatch: baz" $ onMatch' (overMatch' baz) == "baz: true"
 
-  assert' "onMatch mapSomeExpand: foo" $ onMatch' (mapSomeExpand' foo) == "foo: 42"
-  assert' "onMatch mapSomeExpand: bar" $ onMatch' (mapSomeExpand' bar) == "bar: bar"
-  assert' "onMatch mapSomeExpand: baz" $ onMatch' (mapSomeExpand' baz) == "baz: true"
-
-  assert' "onMatch mapAll: foo" $ onMatch' (mapAll' foo) == "foo: 42"
-  assert' "onMatch mapAll: bar" $ onMatch' (mapAll' bar) == "bar: bar"
-  assert' "onMatch mapAll: baz" $ onMatch' (mapAll' baz) == "baz: true"
+  assert' "onMatch expandOverMatch: foo" $ onMatch' (expandOverMatch' foo) == "foo: 42"
+  assert' "onMatch expandOverMatch: bar" $ onMatch' (expandOverMatch' bar) == "bar: bar"
+  assert' "onMatch expandOverMatch: baz" $ onMatch' (expandOverMatch' baz) == "baz: true"
 
   assert' "eq: foo" $ (foo ∷ Variant TestVariants) == foo
   assert' "eq: bar" $ (bar ∷ Variant TestVariants) == bar

--- a/test/VariantF.purs
+++ b/test/VariantF.purs
@@ -3,7 +3,7 @@ module Test.VariantF where
 import Prelude
 
 import Data.Either (Either(..))
-import Data.Functor.Variant (FProxy, SProxy(..), VariantF, case_, contract, default, expand, inj, mapAll, mapSome, mapSomeExpand, match, on, onMatch, prj, revariantF, unvariantF)
+import Data.Functor.Variant (FProxy, SProxy(..), VariantF, case_, contract, default, expand, inj, overMatch, expandOverMatch, match, on, onMatch, prj, revariantF, unvariantF)
 import Data.List as L
 import Data.Maybe (Maybe(..), isJust)
 import Data.Tuple (Tuple(..))
@@ -111,24 +111,15 @@ test = do
     map'' ∷ VariantF TestVariants Int → String
     map'' = map (_ + 2) >>> map'
 
-    mapSome' ∷ VariantF TestVariants Int → VariantF TestVariants Int
-    mapSome' = mapSome
+    overMatch' ∷ VariantF TestVariants Int → VariantF TestVariants Int
+    overMatch' = overMatch
       { baz: \(_ ∷ Either String Int) → Right 20
       } expand
 
-    mapAll' ∷ VariantF TestVariants Int → VariantF TestVariants Int
-    mapAll' = mapAll
-      { baz: \(_ ∷ Either String Int) → Right 20
-      , bar: \a → a
-      , foo: case _ of
-          Nothing → Just 0
-          Just f → Just f
-      }
-
-    mapSomeExpand' ∷ forall r.
+    expandOverMatch' ∷ forall r.
       VariantF (baz ∷ FProxy (Either String) | r) Int →
       VariantF (baz ∷ FProxy (Either String) | r) Int
-    mapSomeExpand' = mapSomeExpand
+    expandOverMatch' = expandOverMatch
       { baz: \(_ ∷ Either String Int) → Right 20
       } identity
 
@@ -136,17 +127,13 @@ test = do
   assert' "map: bar" $ map'' bar == "bar: (Tuple \"bar\" 44)"
   assert' "map: baz" $ map'' baz == "baz: (Left \"baz\")"
 
-  assert' "mapSome: foo" $ map'' (mapSome' foo) == "foo: (Just 44)"
-  assert' "mapSome: bar" $ map'' (mapSome' bar) == "bar: (Tuple \"bar\" 44)"
-  assert' "mapSome: baz" $ map'' (mapSome' baz) == "baz: (Right 22)"
+  assert' "overMatch: foo" $ map'' (overMatch' foo) == "foo: (Just 44)"
+  assert' "overMatch: bar" $ map'' (overMatch' bar) == "bar: (Tuple \"bar\" 44)"
+  assert' "overMatch: baz" $ map'' (overMatch' baz) == "baz: (Right 22)"
 
-  assert' "mapSomeExpand: foo" $ map'' (mapSomeExpand' foo) == "foo: (Just 44)"
-  assert' "mapSomeExpand: bar" $ map'' (mapSomeExpand' bar) == "bar: (Tuple \"bar\" 44)"
-  assert' "mapSomeExpand: baz" $ map'' (mapSomeExpand' baz) == "baz: (Right 22)"
-
-  assert' "mapAll: foo" $ map'' (mapAll' foo) == "foo: (Just 44)"
-  assert' "mapAll: bar" $ map'' (mapAll' bar) == "bar: (Tuple \"bar\" 44)"
-  assert' "mapAll: baz" $ map'' (mapAll' baz) == "baz: (Right 22)"
+  assert' "expandOverMatch: foo" $ map'' (expandOverMatch' foo) == "foo: (Just 44)"
+  assert' "expandOverMatch: bar" $ map'' (expandOverMatch' bar) == "bar: (Tuple \"bar\" 44)"
+  assert' "expandOverMatch: baz" $ map'' (expandOverMatch' baz) == "baz: (Right 22)"
 
   assert' "contract: pass"
     $ isJust

--- a/test/VariantF.purs
+++ b/test/VariantF.purs
@@ -3,7 +3,7 @@ module Test.VariantF where
 import Prelude
 
 import Data.Either (Either(..))
-import Data.Functor.Variant (VariantF, case_, contract, default, expand, expandOverMatch, inj, match, on, onMatch, overMatch, prj, revariantF, unvariantF)
+import Data.Functor.Variant (VariantF, case_, contract, default, expand, inj, match, on, onMatch, over, overSome, prj, revariantF, unvariantF)
 import Data.List as L
 import Data.Maybe (Maybe(..), isJust)
 import Data.Tuple (Tuple(..))
@@ -112,15 +112,15 @@ test = do
     map'' ∷ VariantF TestVariants Int → String
     map'' = map (_ + 2) >>> map'
 
-    overMatch' ∷ VariantF TestVariants Int → VariantF TestVariants Int
-    overMatch' = overMatch
+    overSome' ∷ VariantF TestVariants Int → VariantF TestVariants Int
+    overSome' = overSome
       { baz: \(_ ∷ Either String Int) → Right 20
       } expand
 
-    expandOverMatch' ∷ forall r.
+    over' ∷ forall r.
       VariantF (baz ∷ Either String | r) Int →
       VariantF (baz ∷ Either String | r) Int
-    expandOverMatch' = expandOverMatch
+    over' = over
       { baz: \(_ ∷ Either String Int) → Right 20
       } identity
 
@@ -128,13 +128,13 @@ test = do
   assert' "map: bar" $ map'' bar == "bar: (Tuple \"bar\" 44)"
   assert' "map: baz" $ map'' baz == "baz: (Left \"baz\")"
 
-  assert' "overMatch: foo" $ map'' (overMatch' foo) == "foo: (Just 44)"
-  assert' "overMatch: bar" $ map'' (overMatch' bar) == "bar: (Tuple \"bar\" 44)"
-  assert' "overMatch: baz" $ map'' (overMatch' baz) == "baz: (Right 22)"
+  assert' "overSome: foo" $ map'' (overSome' foo) == "foo: (Just 44)"
+  assert' "overSome: bar" $ map'' (overSome' bar) == "bar: (Tuple \"bar\" 44)"
+  assert' "overSome: baz" $ map'' (overSome' baz) == "baz: (Right 22)"
 
-  assert' "expandOverMatch: foo" $ map'' (expandOverMatch' foo) == "foo: (Just 44)"
-  assert' "expandOverMatch: bar" $ map'' (expandOverMatch' bar) == "bar: (Tuple \"bar\" 44)"
-  assert' "expandOverMatch: baz" $ map'' (expandOverMatch' baz) == "baz: (Right 22)"
+  assert' "over: foo" $ map'' (over' foo) == "foo: (Just 44)"
+  assert' "over: bar" $ map'' (over' bar) == "bar: (Tuple \"bar\" 44)"
+  assert' "over: baz" $ map'' (over' baz) == "baz: (Right 22)"
 
   assert' "contract: pass"
     $ isJust


### PR DESCRIPTION
Fixes #36.

This is a work-in progress. In particular, I don't know of a way to come up with the correct `map` function for the `VariantF` that is generated from `mapSome`. Will we have to collect `map` dictionaries (corresponding to `ro` row), and then search for it in there?

Note: `mapAll` has a different implementation from `mapSome` only because the compiler doesn't solve `Union r () r`, and it is a constraint I don't want to propagate to the user. Otherwise it would be `mapAll r = mapSome r case_`.

Also need to write tests. All in good time :wink: