### PR TITLE
Remove typelevel-prelude dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,10 +28,10 @@
     "purescript-unsafe-coerce": "^4.0.0",
     "purescript-partial": "^2.0.0",
     "purescript-maybe": "^4.0.0",
-    "purescript-typelevel-prelude": "^5.0.0",
     "purescript-lists": "^5.0.0",
     "purescript-record": "^2.0.0",
-    "purescript-enums": "^4.0.0"
+    "purescript-enums": "^4.0.0",
+    "purescript-proxy": "^3.0.0"
   },
   "devDependencies": {
     "purescript-console": "^4.0.0",


### PR DESCRIPTION
We only use the `proxy` transitive dependency.