### PR TITLE
Remove proxy re-exports

### DIFF
--- a/src/Data/Functor/Variant.purs
+++ b/src/Data/Functor/Variant.purs
@@ -27,7 +27,6 @@ import Prelude
 
 import Control.Alternative (class Alternative, empty)
 import Data.List as L
-import Data.Symbol (SProxy(..)) as Exports
 import Data.Symbol (class IsSymbol, reflectSymbol)
 import Data.Traversable as TF
 import Data.Variant.Internal (class Contractable, class VariantFMatchCases) as Exports
@@ -37,7 +36,6 @@ import Prim.Row as R
 import Prim.RowList as RL
 import Type.Equality (class TypeEquals)
 import Type.Proxy (Proxy(..))
-import Type.Proxy (Proxy(..)) as Exports
 import Unsafe.Coerce (unsafeCoerce)
 
 newtype VariantFRep f a = VariantFRep

--- a/src/Data/Variant.purs
+++ b/src/Data/Variant.purs
@@ -27,7 +27,6 @@ import Control.Alternative (empty, class Alternative)
 import Data.Enum (class Enum, pred, succ, class BoundedEnum, Cardinality(..), fromEnum, toEnum, cardinality)
 import Data.List as L
 import Data.Maybe (Maybe)
-import Data.Symbol (SProxy(..)) as Exports
 import Data.Symbol (class IsSymbol, reflectSymbol)
 import Data.Variant.Internal (class Contractable, class VariantMatchCases) as Exports
 import Data.Variant.Internal (class Contractable, class VariantMatchCases, class VariantTags, BoundedDict, BoundedEnumDict, VariantCase, VariantRep(..), contractWith, lookup, lookupCardinality, lookupEq, lookupFirst, lookupFromEnum, lookupLast, lookupOrd, lookupPred, lookupSucc, lookupToEnum, unsafeGet, unsafeHas, variantTags)
@@ -35,7 +34,6 @@ import Partial.Unsafe (unsafeCrashWith)
 import Prim.Row as R
 import Prim.RowList as RL
 import Type.Proxy (Proxy(..))
-import Type.Proxy (Proxy(..)) as Exports
 import Unsafe.Coerce (unsafeCoerce)
 
 foreign import data Variant ∷ Row Type → Type

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -21,9 +21,6 @@ module Data.Variant.Internal
   , BoundedEnumDict
   , impossible
   , module Exports
-  , module Type.Data.Row
-  , module Type.Data.RowList
-  , module Type.Proxy
   ) where
 
 import Prelude
@@ -37,8 +34,6 @@ import Partial.Unsafe (unsafeCrashWith)
 import Prim.Row as R
 import Prim.RowList as RL
 import Record.Unsafe (unsafeGet, unsafeHas) as Exports
-import Type.Data.Row (RProxy(..))
-import Type.Data.RowList (RLProxy(..))
 import Type.Proxy (Proxy(..))
 import Type.Equality (class TypeEquals)
 

--- a/test/Variant.purs
+++ b/test/Variant.purs
@@ -5,10 +5,11 @@ import Prelude
 import Data.List as L
 import Data.Maybe (Maybe(..), isJust)
 import Data.Symbol (reflectSymbol)
-import Data.Variant (Variant, on, onMatch, case_, default, inj, prj, SProxy(..), match, contract, Unvariant(..), unvariant, revariant)
-import Record.Builder (build, modify, Builder())
-import Test.Assert (assert')
+import Data.Variant (Variant, on, onMatch, case_, default, inj, prj, match, contract, Unvariant(..), unvariant, revariant)
 import Effect (Effect)
+import Record.Builder (build, modify, Builder)
+import Test.Assert (assert')
+import Type.Proxy (Proxy(..))
 
 type TestVariants =
   ( foo ∷ Int
@@ -16,14 +17,14 @@ type TestVariants =
   , baz ∷ Boolean
   )
 
-_foo ∷ SProxy "foo"
-_foo = SProxy
+_foo ∷ Proxy "foo"
+_foo = Proxy
 
-_bar ∷ SProxy "bar"
-_bar = SProxy
+_bar ∷ Proxy "bar"
+_bar = Proxy
 
-_baz ∷ SProxy "baz"
-_baz = SProxy
+_baz ∷ Proxy "baz"
+_baz = Proxy
 
 foo ∷ ∀ r. Variant (foo ∷ Int | r)
 foo = inj _foo 42

--- a/test/VariantEnums.purs
+++ b/test/VariantEnums.purs
@@ -4,9 +4,10 @@ import Prelude
 
 import Data.Enum (Cardinality(..), cardinality, succ, pred, toEnum, fromEnum)
 import Data.Maybe (Maybe(..))
-import Data.Variant (SProxy(..), Variant, inj)
+import Data.Variant (Variant, inj)
 import Effect (Effect)
 import Test.Assert (assert')
+import Type.Proxy (Proxy(..))
 
 type T = Variant
   ( a ∷ Unit
@@ -20,9 +21,9 @@ type TT = Variant
   , c ∷ T
   )
 
-_a = SProxy ∷ SProxy "a"
-_b = SProxy ∷ SProxy "b"
-_c = SProxy ∷ SProxy "c"
+_a = Proxy ∷ Proxy "a"
+_b = Proxy ∷ Proxy "b"
+_c = Proxy ∷ Proxy "c"
 
 test ∷ Effect Unit
 test = do

--- a/test/VariantF.purs
+++ b/test/VariantF.purs
@@ -3,12 +3,13 @@ module Test.VariantF where
 import Prelude
 
 import Data.Either (Either(..))
-import Data.Functor.Variant (Proxy(..), VariantF, case_, contract, default, inj, match, on, onMatch, prj, revariantF, unvariantF)
+import Data.Functor.Variant (VariantF, case_, contract, default, inj, match, on, onMatch, prj, revariantF, unvariantF)
 import Data.List as L
 import Data.Maybe (Maybe(..), isJust)
 import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Test.Assert (assert')
+import Type.Proxy(Proxy(..))
 
 type TestVariants =
   ( foo ∷ Maybe


### PR DESCRIPTION
Closes #50 by removing the re-exports for `SProxy`, `RProxy`, `RLProxy`, etc. (which are deprecated) and `Proxy` (which is already in the Prelude). I'm not sure how this should be handled wrt a release; this probably should have been a part of the v7.0.0 release in the first place.

Edit: I'm going to release this as a patch.