### PR TITLE
Remove unused names

### DIFF
--- a/src/Data/Functor/Variant.purs
+++ b/src/Data/Functor/Variant.purs
@@ -94,7 +94,7 @@ class FoldableVFRL rl row <= TraversableVFRL rl row | rl -> row where
   traverseVFRL :: forall proxy f a b. Applicative f => proxy rl -> (a -> f b) -> VariantF row a -> f (VariantF row b)
 
 instance traversableNil :: TraversableVFRL RL.Nil () where
-  traverseVFRL _ f = case_
+  traverseVFRL _ _ = case_
 
 instance traversableCons ::
   ( IsSymbol k

--- a/src/Data/Variant.purs
+++ b/src/Data/Variant.purs
@@ -319,9 +319,6 @@ instance enumVariantCons ∷ (VariantBoundedEnums rs, BoundedEnum a) ⇒ Variant
       , cardinality: coerceCardinality cardinality
       }
 
-    coerceA ∷ a → VariantCase
-    coerceA = unsafeCoerce
-
     coerceAToMbA ∷ (a → Maybe a) → VariantCase → Maybe VariantCase
     coerceAToMbA = unsafeCoerce
 

--- a/src/Data/Variant/Internal.purs
+++ b/src/Data/Variant/Internal.purs
@@ -174,7 +174,7 @@ lookupPred (VariantRep rep) = go1
       | otherwise → go2 t1 b1 d1 ts1 bs1 ds1
     _, _, _ → impossible "pred"
 
-  go2 t1 b1 d1 = case _, _, _ of
+  go2 t1 b1 _ = case _, _, _ of
     L.Cons t2 ts2, L.Cons b2 bs2, L.Cons d2 ds2
       | t2 == rep.type →
           case d2.pred rep.value of
@@ -193,7 +193,7 @@ lookupSucc
 lookupSucc (VariantRep rep) = go
   where
   go = case _, _, _ of
-    L.Cons t1 ts1, L.Cons b1 bs1, L.Cons d1 ds1
+    L.Cons t1 ts1, L.Cons _ bs1, L.Cons d1 ds1
       | t1 == rep.type →
           case d1.succ rep.value of
             Just z  → Just $ VariantRep { type: t1, value: z }


### PR DESCRIPTION
Removes unused names now reported as warnings as of PureScript 0.14.1.